### PR TITLE
Use a `BTreeMap` for tracks, and `u32` for `TrackId`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,9 @@ mod mp4box;
 pub use mp4box::*;
 
 mod reader;
-pub use reader::*;
+pub use reader::Mp4;
+
+pub use types::{TrackId, TrackKind};
 
 pub fn read(bytes: &[u8]) -> Result<Mp4> {
     let mp4 = reader::Mp4::read(Cursor::new(bytes), bytes.len() as u64)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -165,6 +165,8 @@ const HANDLER_TYPE_AUDIO_FOURCC: [u8; 4] = [b's', b'o', b'u', b'n'];
 const HANDLER_TYPE_SUBTITLE: &str = "sbtl";
 const HANDLER_TYPE_SUBTITLE_FOURCC: [u8; 4] = [b's', b'b', b't', b'l'];
 
+pub type TrackId = u32;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrackKind {
     Video,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -49,7 +49,6 @@ fn assert_video_snapshot(file_path: &str) {
     let bytes = std::fs::read(base_path.join(file_path)).unwrap();
     let video = re_mp4::read(&bytes).unwrap();
 
-    #[allow(clippy::iter_over_hash_type)] // what we do in the iteration is not order-dependent
     for (id, track) in video.tracks() {
         if track.kind == Some(re_mp4::TrackKind::Video) {
             assert_snapshot(


### PR DESCRIPTION
Using a `BTreeMap` makes it easier to find e.g. the first video track. It also means iterating over all tracks is deterministic.
