### PR TITLE
Add profiling scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +123,7 @@ dependencies = [
  "bytes",
  "log",
  "num-rational",
+ "profiling",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ byteorder = "1"
 bytes = "1.1.0"
 log = "0.4.17"
 num-rational = { version = "0.4.0", features = ["serde"] }
+profiling = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "^1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //!    * ISO/IEC 14496-14 - MP4 file format
 //!    * ISO/IEC 14496-17 - Streaming text format
 //!
+//! The top-level type you wanna look at is [`Mp4`].
 
 mod error;
 pub use error::Error;

--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -276,6 +276,7 @@ impl BoxHeader {
     }
 
     // TODO: if size is 0, then this box is the last one in the file
+    #[profiling::function]
     pub fn read<R: Read>(reader: &mut R) -> Result<Self> {
         // Create and read to buf.
         let mut buf = [0u8; 8]; // 8 bytes for box header.


### PR DESCRIPTION
Using this, it is easy to see that most time is taken up by `load_track_data`, and its memory allocations.

We should instead store byte ranges. Once we do that, parsing should be almost instantaneous, and this PR is not needed