### PR TITLE
Handle negative data_offset in TrunBox

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -383,7 +383,8 @@ impl Mp4 {
 
                         let sample_offset = if traf_idx == 0 && sample_n == 0 {
                             if data_offset_present {
-                                base_data_offset + trun.data_offset.unwrap_or(0) as u64
+                                base_data_offset
+                                    .saturating_add_signed(trun.data_offset.unwrap_or(0) as i64)
                             } else {
                                 base_data_offset
                             }


### PR DESCRIPTION
As a followup to #14 briefly vetted all u64 and u32 casts.
The only one that looked suspicious was data_offset. Didn't find much about it quickly, only that gstreamer also distinctively uses a signed integer, so let's not cast that away (which would potentially cause more overflow errors on debug builds) https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/e5d2dd8e8d9f9df1f33e44ffe296cc55d7b55346/subprojects/gst-plugins-good/gst/isomp4/atoms.h#L812

* [x] tested against Rerun