### PR TITLE
Account for video with DTS shift and resulting negative dts values

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -396,7 +396,7 @@ impl Mp4 {
                                 .copied()
                                 .unwrap_or(default_sample_size) as u64;
 
-                        // Sample offset in bytes. (Must be postive, otherwise this would be outside of the file.)
+                        // Sample offset in bytes. (Must be positive, otherwise this would be outside of the file.)
                         let sample_offset = if traf_idx == 0 && sample_n == 0 {
                             if data_offset_present {
                                 base_data_offset


### PR DESCRIPTION
This fixes
* https://github.com/rerun-io/rerun/issues/8098

Other mp4 parsers/data processors apply similar things:
* ffmpeg does, see code comments
* this one does https://github.com/kaltura/nginx-vod-module/blob/26f06877b0f2a2336e59cda93a3de18d7b23a3e2/vod/mp4/mp4_parser.c#L1205
* mp4 box does not!

... still this begs the question:
* is this speced? couldn't find anything
* this blurs the line a bit of what "the raw PTS/DTS" is. Rerun already offsets by min PTS. Maybe we should do that as well inside re_mp4. This way, ffprobe's output would always match ours (it does not right now as it's shifted by the min PTS, see example below)


First 6 frames in Rerun of the video from https://github.com/rerun-io/rerun/issues/8098:

<img width="374" alt="image" src="https://github.com/user-attachments/assets/2e3b8bb3-3d7a-4634-a4f1-e6e066829cb5">

And for comparison the same frames from ffprobe, using `ffprobe -of json  -show_packets -select_streams v ../internal-test-assets/dtsbroken.mp4 > dtsbroken.json`:
```json
 {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 0,
            "pts_time": "0.000000",
            "dts": -2002,
            "dts_time": "-0.066733",
            "size": "51711",
            "pos": "24912",
            "flags": "K__"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 4004,
            "pts_time": "0.133467",
            "dts": -1001,
            "dts_time": "-0.033367",
            "size": "7564",
            "pos": "79488",
            "flags": "___"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 2002,
            "pts_time": "0.066733",
            "dts": 0,
            "dts_time": "0.000000",
            "size": "2192",
            "pos": "87052",
            "flags": "___"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 1001,
            "pts_time": "0.033367",
            "dts": 1001,
            "dts_time": "0.033367",
            "size": "1911",
            "pos": "89244",
            "flags": "___"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 3003,
            "pts_time": "0.100100",
            "dts": 2002,
            "dts_time": "0.066733",
            "size": "1168",
            "pos": "91155",
            "flags": "___"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 8008,
            "pts_time": "0.266933",
            "dts": 3003,
            "dts_time": "0.100100",
            "size": "7874",
            "pos": "94674",
            "flags": "___"
        },
```
Note that this matches now for this video!

---

However, on "timestamped bunny" we still have the min pts discrepancy which we account for upon query in Rerun (unchanged from before/after this PR!): 
<img width="382" alt="image" src="https://github.com/user-attachments/assets/18c416e8-bfaa-431b-bd45-7ba4a18e03b6">
```json
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 0,
            "pts_time": "0.000000",
            "dts": -512,
            "dts_time": "-0.033333",
            "duration": 256,
            "duration_time": "0.016667",
            "size": "190349",
            "pos": "48",
            "flags": "K__"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 1024,
            "pts_time": "0.066667",
            "dts": -256,
            "dts_time": "-0.016667",
            "duration": 256,
            "duration_time": "0.016667",
            "size": "13884",
            "pos": "190397",
            "flags": "___"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 512,
            "pts_time": "0.033333",
            "dts": 0,
            "dts_time": "0.000000",
            "duration": 256,
            "duration_time": "0.016667",
            "size": "3790",
            "pos": "204281",
            "flags": "___"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 256,
            "pts_time": "0.016667",
            "dts": 256,
            "dts_time": "0.016667",
            "duration": 256,
            "duration_time": "0.016667",
            "size": "2169",
            "pos": "208071",
            "flags": "___"
        },
```

It works, so I'd say we leave it for now 🤔 . But something that might came back to haunt us!
