### PR TITLE
Shift DTS & CTS by minimum CTS to mimick `ffprobe`'s behavior

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -545,10 +545,16 @@ pub struct Sample {
 
     /// Timestamp of the sample at which it should be decoded,
     /// in time units.
+    ///
+    /// This is offsetted:
+    /// * with decode timestamp shift determined from negative sample offsets
+    /// * such that the first [`Self::composition_timestamp`] is zero.
     pub decode_timestamp: i64,
 
     /// Timestamp of the sample at which the sample should be displayed,
     /// in time units.
+    ///
+    /// This is offsetted such that the first composition timestamp is zero.
     pub composition_timestamp: i64,
 
     /// Duration of the sample in time units.


### PR DESCRIPTION
* Followup to #16 

In ffprobe:

```json
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 0,
            "pts_time": "0.000000",
            "dts": -512,
            "dts_time": "-0.033333",
            "duration": 256,
            "duration_time": "0.016667",
            "size": "190349",
            "pos": "48",
            "flags": "K__"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 1024,
            "pts_time": "0.066667",
            "dts": -256,
            "dts_time": "-0.016667",
            "duration": 256,
            "duration_time": "0.016667",
            "size": "13884",
            "pos": "190397",
            "flags": "___"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 512,
            "pts_time": "0.033333",
            "dts": 0,
            "dts_time": "0.000000",
            "duration": 256,
            "duration_time": "0.016667",
            "size": "3790",
            "pos": "204281",
            "flags": "___"
        },
        {
            "codec_type": "video",
            "stream_index": 0,
            "pts": 256,
            "pts_time": "0.016667",
            "dts": 256,
            "dts_time": "0.016667",
            "duration": 256,
            "duration_time": "0.016667",
            "size": "2169",
            "pos": "208071",
            "flags": "___"
        },
```

In Rerun:
![image](https://github.com/user-attachments/assets/1c6afbb7-cdac-49ce-98bf-80c3e6f0cc58)
