### PR TITLE
Fix edge case for parsing video with constant frame size

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -165,7 +165,11 @@ impl Mp4 {
             let stsz = &stbl.stsz;
             let stts = &stbl.stts;
 
-            while sample_n < stsz.sample_sizes.len() {
+
+            // Could probably just always use sample count
+            while (sample_n < stsz.sample_sizes.len() && sample_n == 0)
+                || sample_n < stsz.sample_count.try_into().unwrap()
+            {
                 // compute offset
                 if sample_n == 0 {
                     chunk_index = 1;
@@ -208,7 +212,11 @@ impl Mp4 {
                 }
 
                 let timescale = trak.mdia.mdhd.timescale as u64;
-                let size = stsz.sample_sizes[sample_n] as u64;
+                let size = if stsz.sample_size != 0 {
+                    stsz.sample_size as u64
+                } else {
+                    stsz.sample_sizes[sample_n] as u64
+                };
                 let offset = get_sample_chunk_offset(stbl, chunk_index) + offset_in_chunk;
                 offset_in_chunk += size;
 


### PR DESCRIPTION
I'll link a PR from the main rerun repo. Basically when loading a lerobot dataset with a single frame for a video I got an error about the wrong number of rows for a chunk.

The STSZ format uses `sample_sizes` when the are not uniform but `sample_size` when they are. We weren't accounting for the uniform case and just skipped the samples.
