### PR TITLE
Update VP8 codec_string to be WebGPU compliant

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,8 +125,8 @@ jobs:
     name: Check Rust dependencies (cargo-deny)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           rust-version: "1.76.0"
           log-level: warn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "itoa"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -6,5 +6,5 @@
 
 [toolchain]
 channel = "1.76"  # Avoid specifying a patch version here; see https://github.com/emilk/eframe_template/issues/145
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]

--- a/src/mp4box/stsd.rs
+++ b/src/mp4box/stsd.rs
@@ -102,12 +102,9 @@ impl StsdBoxContent {
                 format!("hev1{}", hevc_codec_details(hvcc))
             }
 
-            Self::Vp08(Vp08Box { vpcc, .. }) => {
-                let profile = vpcc.profile;
-                let level = vpcc.level;
-                let bit_depth = vpcc.bit_depth;
-
-                format!("vp08.{profile:02}.{level:02}.{bit_depth:02}")
+            Self::Vp08(_) => {
+                // https://www.w3.org/TR/webcodecs-vp8-codec-registration/#fully-qualified-codec-strings
+                String::from("vp8")
             }
 
             Self::Vp09(Vp09Box { vpcc, .. }) => {

--- a/tests/codec_detection.rs
+++ b/tests/codec_detection.rs
@@ -61,7 +61,7 @@ fn parse_hev1() {
 
 #[test]
 fn parse_vp8() {
-    test_codec_parsing("bigbuckbunny/vp8.mp4", "vp08", |stsd_box: &StsdBox| {
+    test_codec_parsing("bigbuckbunny/vp8.mp4", "vp8", |stsd_box: &StsdBox| {
         assert!(matches!(stsd_box.contents, StsdBoxContent::Vp08(_)));
     });
 }


### PR DESCRIPTION
ref: https://github.com/rerun-io/rerun/pull/12742#pullrequestreview-4203723628

Fixes `vp8` playback on web

Changes:

- [x] Update codec string to 'vp8'
- [x] Update test
- [x] add `rust-analyzer` in rust-toolchain file, required for rust-analyzer to work in IDE for this toolchain 