### PR TITLE
Improve crate docstring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! `mp4` is a Rust library to read and write ISO-MP4 files.
+//! `re_mp4` is a Rust library to parse ISO-MP4 files.
 //!
 //! This package contains MPEG-4 specifications defined in parts:
 //!    * ISO/IEC 14496-12 - ISO Base Media File Format (`QuickTime`, MPEG-4, etc)


### PR DESCRIPTION
This fixes https://docs.rs/re_mp4/0.5.0/re_mp4/ saying

> `mp4` is a Rust library to read and write ISO-MP4 files.

21ccd8fd4e657b067c90af31a32baea6c4c5d68e removed src/writer.rs; 35baa38cc77897dbd1aabe66cd09a61893daf826 renamed the crate to re_mp4.
