### PR TITLE
Pin cargo-machete and typos to their latest releases

### DIFF
--- a/.github/workflows/cargo_machete.yml
+++ b/.github/workflows/cargo_machete.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Machete
-        uses: bnjbvr/cargo-machete@main
+        uses: bnjbvr/cargo-machete@v0.9.2

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check spelling of entire workspace
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.49.0


### PR DESCRIPTION
`bnjbvr/cargo-machete@main` and `crate-ci/typos@master` are branch refs, so CI ran whatever was last pushed there. Pinned cargo-machete to v0.9.2 (2026-04-15) and typos to v1.49.0 (2026-08-03), both latest.